### PR TITLE
Fix for rgb(RR,GG,BB) with whitespaces after comma

### DIFF
--- a/autoload/Colorizer.vim
+++ b/autoload/Colorizer.vim
@@ -1302,7 +1302,7 @@ function! s:SaveOptions(list) "{{{1
 endfunction
 
 function! s:StripParentheses(val) "{{{1
-    return split(matchstr(a:val, '^\(hsl\|rgb\)a\?\s*(\zs[^)]*\ze)'), '\s*,')
+    return split(matchstr(a:val, '^\(hsl\|rgb\)a\?\s*(\zs[^)]*\ze)'), '\s*,\s*')
 endfunction
 
 function! s:ColorRGBValues(val) "{{{1


### PR DESCRIPTION
It didn't work cases like rgb(50, 60, 70) because of spaces.
