### PR TITLE
Latest neovim still reports v:version 704

### DIFF
--- a/autoload/Colorizer.vim
+++ b/autoload/Colorizer.vim
@@ -2245,7 +2245,7 @@ endfu
 function! Colorizer#DoColor(force, line1, line2, ...) "{{{1
     " initialize plugin
     try
-        if v:version < 800
+        if v:version < 800 && !has('nvim')
             call s:Warn("Colorizer needs Vim 8.0")
             return
         endif


### PR DESCRIPTION
I had to make this change to use the plugin with latest nvim stable.