### PR TITLE
Ignore generated tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+doc/tags
 post.pl
 vim_passfile
 .*.un~


### PR DESCRIPTION
Keeps my `.vim` repo cleaner when using Colorizer as a submodule

Otherwise it shows changes as `Colorizer/docs/tags` are generated