### PR TITLE
Implement option for Neovim virtual text

### DIFF
--- a/autoload/Colorizer.vim
+++ b/autoload/Colorizer.vim
@@ -1697,7 +1697,16 @@ function! s:SetMatch(group, pattern, param_dict) "{{{1
         return
     endif
     " let 'hls' overrule our syntax highlighting
-    call matchadd(a:group, a:pattern, s:default_match_priority)
+
+    if has('nvim') &&
+      \ exists('g:colorizer_use_virtual_text')
+        let line_no = line('.')
+        let line_no -= 1
+        call nvim_buf_set_virtual_text(0, 0, line_no, [['  ', a:group]], {})
+    else
+        call matchadd(a:group, a:pattern, s:default_match_priority)
+    endif
+
     call add(w:match_list, a:pattern)
 endfunction
 

--- a/doc/Colorizer.txt
+++ b/doc/Colorizer.txt
@@ -35,6 +35,7 @@ Contents                                                        *Colorizer*
             2.12 Colorizing :hi statements...........|Colorizer-vim-hi|
             2.13 Disable BufLeave autocomannd........|Colorizer-BufLeave|
             2.14 Control which autocommands trigger  |Colorizer-autocommands| 
+            2.15 Rendering colors as virtual text....*Colorizer-virtual-text*
     3.  Colorizer Mappings...........................|Colorizer-maps|
     4.  Colorizer Tips...............................|Colorizer-tips|
     5.  Colorizer Feedback...........................|Colorizer-feedback|
@@ -286,6 +287,17 @@ variable: >
 
 Where <autocommand> is the event to be disabled. So to disable the TextChanged
 autocommand, set `:let g:colorizer_textchangedi = 0`
+
+2.15 Rendering colors as virtual text                  *Colorizer-virtual-text*
+-------------------------------------
+
+(Neovim only)
+
+Rather than matching the colors add adding the corresponding syntax rules to
+them, it is possible to render the colors as swatches at the end of each line,
+leveraging Neovim's virtual text. To do this, you can set:
+
+    `let g:colorizer_use_virtual_text = 1`
 
 ==============================================================================
 3. Colorizer Mappings                                      *Colorizer-maps*


### PR DESCRIPTION
I use Neovim, and I always found the style of setting the background color on everything to be a little unseemly. So I added a little option to allow adding the color as a swatch to the virtual text buffer. Thought it might have some wider appeal.

This is the first time I've ever written any serious Vim Script, and I had a little trouble following the way it worked. So I hope I've added it in the right place and done an alright job with the documentation and stuff.

<img width="451" alt="image" src="https://user-images.githubusercontent.com/1707318/56462067-75047400-63b4-11e9-8f99-011ba72239d5.png">
