### PR TITLE
Create Color_* groups when s:HasGui()

### DIFF
--- a/autoload/Colorizer.vim
+++ b/autoload/Colorizer.vim
@@ -1621,7 +1621,25 @@ function! s:DoHlGroup(group, Dict) "{{{1
     endif
     let hi .= printf('%s', !empty(get(a:Dict, 'special', '')) ?
         \ (' gui='. a:Dict.special) : '')
-    if !s:HasGui()
+    if s:HasGui()
+        let fg = get(a:Dict, 'guifg', '')
+        let bg = get(a:Dict, 'guibg', '')
+        let [fg, bg] = s:SwapColors([fg, bg])
+        if !empty(bg) || bg == 0
+            let hi.= printf(' guibg=%s', bg)
+        endif
+        if !empty(fg) || fg == 0
+            let hi.= printf(' guifg=%s', fg)
+        endif
+        let hi .= printf('%s', !empty(get(a:Dict, 'special','')) ?
+          \ (' gui='. a:Dict.special) : '')
+        if has_key(a:Dict, "term")
+            let hi.=printf(" term=%s ", a:Dict['term'])
+        endif
+        if has_key(a:Dict, "gui")
+            let hi.=printf(" gui=%s ", a:Dict['gui'])
+        endif
+    else
         let fg = get(a:Dict, 'ctermfg', '')
         let bg = get(a:Dict, 'ctermbg', '')
         let [fg, bg] = s:SwapColors([fg, bg])


### PR DESCRIPTION
In gvim, and terminal vim with `set termguicolors`, certain scenarios trigger this error:

```
Colorizer: Some error occured here:  Colorize: ['^\s*\%(\%[Html]HiLink\s\+\w\+\s\+\w\+\)\|\(^\s*hi\%[ghlight]!\?\s\+\(clear\)\@!\S\+.*\)', function('<SNR>144_PreviewVimHighlight'), 'colorizer_vimhighlight', '&ft ==# "vim"', []]
Colorizer: Position: [0, 1, 1, 0]
```

This was triggered by running `:ColorHighlight` on a file containing the single line:

```vim
  highlight QuickFixLine NONE
```

The line triggering the error is [autoload/Colorizer.vim#1734](https://github.com/chrisbra/Colorizer/blob/master/autoload/Colorizer.vim#L1734):

```vim
call matchadd(a:group, a:pattern, s:default_match_priority)
```

... which errors with E28, as the highlight group `Color_QuickFixLine` has not been created.