### PR TITLE
Do not duplicate guibg/guifg

### DIFF
--- a/autoload/Colorizer.vim
+++ b/autoload/Colorizer.vim
@@ -1607,39 +1607,18 @@ function! s:DoHlGroup(group, Dict) "{{{1
     if !empty(bg) && bg[0] !=# '#' && bg !=# 'NONE'
         let bg='#'.bg
     endif
-    if !empty(fg)
-        let hi .= printf('guifg=%s', fg)
-    endif
+    let hi .= printf('guifg=%s', fg)
     if has_key(a:Dict, "gui")
         let hi.=printf(" gui=%s ", a:Dict['gui'])
     endif
     if has_key(a:Dict, "guifg")
         let hi.=printf(" guifg=%s ", a:Dict['guifg'])
     endif
-    if !empty(bg)
-        let hi .= printf(' guibg=%s', bg)
-    endif
+    let hi .= printf(' guibg=%s', bg)
     let hi .= printf('%s', !empty(get(a:Dict, 'special', '')) ?
         \ (' gui='. a:Dict.special) : '')
-    if s:HasGui()
-        let fg = get(a:Dict, 'guifg', '')
-        let bg = get(a:Dict, 'guibg', '')
-        let [fg, bg] = s:SwapColors([fg, bg])
-        if !empty(bg) || bg == 0
-            let hi.= printf(' guibg=%s', bg)
-        endif
-        if !empty(fg) || fg == 0
-            let hi.= printf(' guifg=%s', fg)
-        endif
-        let hi .= printf('%s', !empty(get(a:Dict, 'special','')) ?
-          \ (' gui='. a:Dict.special) : '')
-        if has_key(a:Dict, "term")
-            let hi.=printf(" term=%s ", a:Dict['term'])
-        endif
-        if has_key(a:Dict, "gui")
-            let hi.=printf(" gui=%s ", a:Dict['gui'])
-        endif
-    else
+
+    if !s:HasGui()
         let fg = get(a:Dict, 'ctermfg', '')
         let bg = get(a:Dict, 'ctermbg', '')
         let [fg, bg] = s:SwapColors([fg, bg])


### PR DESCRIPTION
PR #73 broke highlighting in neovim, and after some debugging I see that that PR was resolving the issue in the wrong way.

The issue was that statements of the form `highlight QuickFixLine NONE` would pass argument `a:Dict` to `s:DoHlGroup` containing simply `{'name': 'QuickFixLine'}`, with no `fg`/`bg` properties. PR #73 resolved this by ensuring these properties were included in the resulting command: `hi Color_QuickFixLine guibg= guifg=`.

However, highlights that _did_ have `fg`/`bg` properties were subsequently resulting in a command with duplicate `guifg`/`guibg` elements, like this: `hi Color_000000_98c379 guifg=#000000 guibg=#98c379 guibg= guifg=`. In Vim this worked fine - the first `guifg`/`guibg` element was used and the 2nd ignored, but in neovim it is the other way around, so all highlights were being set to `guibg= guifg=`.

This PR rolls those changes back, and simply ensures that the `guifg`/`guibg` elements are _always_ included in the command, even when they are empty:

```vim
hi Color_QuickFixLine guifg= guibg=
hi Color_000000_98c379 guifg=#000000 guibg=#98c379
```

Closes #74